### PR TITLE
Markus branch

### DIFF
--- a/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/record/cipher/RecordStreamCipherTest.java
+++ b/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/record/cipher/RecordStreamCipherTest.java
@@ -639,16 +639,11 @@ public class RecordStreamCipherTest {
         byte[] data = ArrayConverter
                 .hexStringToByteArray("01010101010101010101010101010101");
 
-        /* Sets a new keySet
-        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
         KeySet keySet = new KeySet();
-        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
-         * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
-         * rc4 can have a key length from 40 bit up to 256 bit
-         * First we're generating the keys for RC4 with SHA*/
+
         keySet.setClientWriteKey(ArrayConverter
                 .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
-        /*The key length for HMAC-SHA are 20 bytes*/
+
         keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
         keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
         keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
@@ -661,24 +656,13 @@ public class RecordStreamCipherTest {
         Record record = new Record();
         record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
         record.prepareComputations();
-        /* sequence numbers are 64-bits long */
+
         record.setSequenceNumber(new BigInteger("0"));
         record.setProtocolVersion(ProtocolVersion.TLS10.getValue());
         record.setCleanProtocolMessageBytes(data);
 
-        /* the cipher is computed over the plaintext(data) and the mac
-         * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
         cipher.encrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 01 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603010010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -739,15 +723,6 @@ public class RecordStreamCipherTest {
 
         plaintext.decrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 01 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603010010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -790,16 +765,11 @@ public class RecordStreamCipherTest {
         byte[] data = ArrayConverter
                 .hexStringToByteArray("01010101010101010101010101010101");
 
-        /* Sets a new keySet
-        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
         KeySet keySet = new KeySet();
-        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
-         * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
-         * rc4 can have a key length from 40 bit up to 256 bit
-         * First we're generating the keys for RC4 with SHA*/
+
         keySet.setClientWriteKey(ArrayConverter
                 .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
-        /*The key length for HMAC-SHA are 20 bytes*/
+
         keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
         keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
         keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
@@ -812,24 +782,13 @@ public class RecordStreamCipherTest {
         Record record = new Record();
         record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
         record.prepareComputations();
-        /* sequence numbers are 64-bits long */
+
         record.setSequenceNumber(new BigInteger("0"));
         record.setProtocolVersion(ProtocolVersion.TLS10.getValue());
         record.setCleanProtocolMessageBytes(data);
 
-        /* the cipher is computed over the plaintext(data) and the mac
-         * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
         cipher.encrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 01 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603010010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -890,15 +849,6 @@ public class RecordStreamCipherTest {
 
         plaintext.decrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 01 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603010010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -941,16 +891,11 @@ public class RecordStreamCipherTest {
         byte[] data = ArrayConverter
                 .hexStringToByteArray("01010101010101010101010101010101");
 
-        /* Sets a new keySet
-        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
         KeySet keySet = new KeySet();
-        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
-         * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
-         * rc4 can have a key length from 40 bit up to 256 bit
-         * First we're generating the keys for RC4 with SHA*/
+
         keySet.setClientWriteKey(ArrayConverter
                 .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
-        /*The key length for HMAC-SHA are 20 bytes*/
+
         keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
         keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
         keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
@@ -963,24 +908,13 @@ public class RecordStreamCipherTest {
         Record record = new Record();
         record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
         record.prepareComputations();
-        /* sequence numbers are 64-bits long */
+
         record.setSequenceNumber(new BigInteger("0"));
         record.setProtocolVersion(ProtocolVersion.TLS11.getValue());
         record.setCleanProtocolMessageBytes(data);
 
-        /* the cipher is computed over the plaintext(data) and the mac
-         * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
         cipher.encrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 02 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603020010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -1041,15 +975,6 @@ public class RecordStreamCipherTest {
 
         plaintext.decrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 02 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603020010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -1092,16 +1017,11 @@ public class RecordStreamCipherTest {
         byte[] data = ArrayConverter
                 .hexStringToByteArray("01010101010101010101010101010101");
 
-        /* Sets a new keySet
-        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
         KeySet keySet = new KeySet();
-        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
-         * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
-         * rc4 can have a key length from 40 bit up to 256 bit
-         * First we're generating the keys for RC4 with SHA*/
+
         keySet.setClientWriteKey(ArrayConverter
                 .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
-        /*The key length for HMAC-SHA are 20 bytes*/
+
         keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
         keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
         keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
@@ -1114,24 +1034,13 @@ public class RecordStreamCipherTest {
         Record record = new Record();
         record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
         record.prepareComputations();
-        /* sequence numbers are 64-bits long */
+
         record.setSequenceNumber(new BigInteger("0"));
         record.setProtocolVersion(ProtocolVersion.TLS11.getValue());
         record.setCleanProtocolMessageBytes(data);
 
-        /* the cipher is computed over the plaintext(data) and the mac
-         * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
         cipher.encrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 02 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603020010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -1192,15 +1101,6 @@ public class RecordStreamCipherTest {
 
         plaintext.decrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 02 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603020010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -1239,20 +1139,14 @@ public class RecordStreamCipherTest {
         /* Sets the SSL/TLS version */
         context.setSelectedProtocolVersion(ProtocolVersion.TLS12);
 
-        /* Sets the data that should be encrypted later */
         byte[] data = ArrayConverter
                 .hexStringToByteArray("01010101010101010101010101010101");
 
-        /* Sets a new keySet
-        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
         KeySet keySet = new KeySet();
-        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
-         * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
-         * rc4 can have a key length from 40 bit up to 256 bit
-         * First we're generating the keys for RC4 with SHA*/
+
         keySet.setClientWriteKey(ArrayConverter
                 .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
-        /*The key length for HMAC-SHA are 20 bytes*/
+
         keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
         keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
         keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
@@ -1265,24 +1159,13 @@ public class RecordStreamCipherTest {
         Record record = new Record();
         record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
         record.prepareComputations();
-        /* sequence numbers are 64-bits long */
+
         record.setSequenceNumber(new BigInteger("0"));
         record.setProtocolVersion(ProtocolVersion.TLS12.getValue());
         record.setCleanProtocolMessageBytes(data);
 
-        /* the cipher is computed over the plaintext(data) and the mac
-         * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
         cipher.encrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 03 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603030010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -1343,15 +1226,6 @@ public class RecordStreamCipherTest {
 
         plaintext.decrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 03 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603030010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -1390,20 +1264,15 @@ public class RecordStreamCipherTest {
         /* Sets the SSL/TLS version */
         context.setSelectedProtocolVersion(ProtocolVersion.TLS12);
 
-        /* Sets the data that should be encrypted later */
+
         byte[] data = ArrayConverter
                 .hexStringToByteArray("01010101010101010101010101010101");
 
-        /* Sets a new keySet
-        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
         KeySet keySet = new KeySet();
-        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
-         * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
-         * rc4 can have a key length from 40 bit up to 256 bit
-         * First we're generating the keys for RC4 with SHA*/
+
         keySet.setClientWriteKey(ArrayConverter
                 .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
-        /*The key length for HMAC-SHA are 20 bytes*/
+
         keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
         keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
         keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
@@ -1416,24 +1285,13 @@ public class RecordStreamCipherTest {
         Record record = new Record();
         record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
         record.prepareComputations();
-        /* sequence numbers are 64-bits long */
+
         record.setSequenceNumber(new BigInteger("0"));
         record.setProtocolVersion(ProtocolVersion.TLS12.getValue());
         record.setCleanProtocolMessageBytes(data);
 
-        /* the cipher is computed over the plaintext(data) and the mac
-         * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
         cipher.encrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 03 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603030010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -1494,15 +1352,6 @@ public class RecordStreamCipherTest {
 
         plaintext.decrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 03 ---+---> authenticated meta data ---+
-         * the message length,                                     00 10 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603030010"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -1541,20 +1390,13 @@ public class RecordStreamCipherTest {
         /* Sets the SSL/TLS version */
         context.setSelectedProtocolVersion(ProtocolVersion.TLS13);
 
-        /* Sets the data that should be encrypted later */
         byte[] data = ArrayConverter
                 .hexStringToByteArray("01010101010101010101010101010101");
 
-        /* Sets a new keySet
-        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
         KeySet keySet = new KeySet();
-        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
-         * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
-         * rc4 can have a key length from 40 bit up to 256 bit
-         * First we're generating the keys for RC4 with SHA*/
+
         keySet.setClientWriteKey(ArrayConverter
                 .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
-        /*The key length for HMAC-SHA are 20 bytes*/
         keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
         keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
         keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
@@ -1567,24 +1409,12 @@ public class RecordStreamCipherTest {
         Record record = new Record();
         record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
         record.prepareComputations();
-        /* sequence numbers are 64-bits long */
-        //record.setSequenceNumber(new BigInteger("0"));
+
         record.setProtocolVersion(ProtocolVersion.TLS13.getValue());
         record.setCleanProtocolMessageBytes(data);
-        /* the cipher is computed over the plaintext(data) and the mac
-         * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
+
         cipher.encrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 04 ---+---> authenticated meta data ---+
-         * the message length,                                     00 24 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
-        System.out.println(record.getComputations().getAuthenticatedMetaData());
-        System.out.println(record.getLength());
         assertArrayEquals(ArrayConverter.hexStringToByteArray("1603040024"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -1645,15 +1475,6 @@ public class RecordStreamCipherTest {
         record.setLength(36);
         plaintext.decrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 04 ---+---> authenticated meta data ---+
-         * the message length,                                     00 24 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("1603040024"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -1692,20 +1513,14 @@ public class RecordStreamCipherTest {
         /* Sets the SSL/TLS version */
         context.setSelectedProtocolVersion(ProtocolVersion.TLS13);
 
-        /* Sets the data that should be encrypted later */
         byte[] data = ArrayConverter
                 .hexStringToByteArray("01010101010101010101010101010101");
 
-        /* Sets a new keySet
-        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
         KeySet keySet = new KeySet();
-        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
-         * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
-         * rc4 can have a key length from 40 bit up to 256 bit
-         * First we're generating the keys for RC4 with SHA*/
+
         keySet.setClientWriteKey(ArrayConverter
                 .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
-        /*The key length for HMAC-SHA are 20 bytes*/
+
         keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
         keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
         keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
@@ -1718,24 +1533,12 @@ public class RecordStreamCipherTest {
         Record record = new Record();
         record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
         record.prepareComputations();
-        /* sequence numbers are 64-bits long */
-        //record.setSequenceNumber(new BigInteger("0"));
+
         record.setProtocolVersion(ProtocolVersion.TLS13.getValue());
         record.setCleanProtocolMessageBytes(data);
 
-        /* the cipher is computed over the plaintext(data) and the mac
-         * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
         cipher.encrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 04 ---+---> authenticated meta data ---+
-         * the message length,                                     00 20 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
-        System.out.println(record.getComputations().getAuthenticatedMetaData());
         assertArrayEquals(ArrayConverter.hexStringToByteArray("1603040020"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 
@@ -1796,15 +1599,6 @@ public class RecordStreamCipherTest {
         record.setLength(32);
         plaintext.decrypt(record);
 
-        /* tests the meta data of the record
-         * the MAC is computed from the MAC secret,
-         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-         * the type field,                                            16 ---+
-         * the protocol version,                                   03 04 ---+---> authenticated meta data ---+
-         * the message length,                                     00 20 ---+                                |
-         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
-         * and two fixed character strings                                                  opad and ipad ---+
-         *  .*/
         assertArrayEquals(ArrayConverter.hexStringToByteArray("1603040020"), record.getComputations()
                 .getAuthenticatedMetaData().getValue());
 

--- a/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/record/cipher/RecordStreamCipherTest.java
+++ b/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/record/cipher/RecordStreamCipherTest.java
@@ -9,22 +9,28 @@
  */
 package de.rub.nds.tlsattacker.core.record.cipher;
 
+import de.rub.nds.modifiablevariable.util.ArrayConverter;
 import de.rub.nds.tlsattacker.core.connection.AliasedConnection;
 import de.rub.nds.tlsattacker.core.connection.InboundConnection;
 import de.rub.nds.tlsattacker.core.connection.OutboundConnection;
-import de.rub.nds.tlsattacker.core.constants.AlgorithmResolver;
-import de.rub.nds.tlsattacker.core.constants.CipherSuite;
-import de.rub.nds.tlsattacker.core.constants.CipherType;
-import de.rub.nds.tlsattacker.core.constants.ProtocolVersion;
+import de.rub.nds.tlsattacker.core.constants.*;
 import de.rub.nds.tlsattacker.core.exceptions.CryptoException;
+import de.rub.nds.tlsattacker.core.record.Record;
+import de.rub.nds.tlsattacker.core.record.cipher.cryptohelper.KeySet;
 import de.rub.nds.tlsattacker.core.record.cipher.cryptohelper.KeySetGenerator;
 import de.rub.nds.tlsattacker.core.state.TlsContext;
+import de.rub.nds.tlsattacker.transport.ConnectionEndType;
 import de.rub.nds.tlsattacker.util.UnlimitedStrengthEnabler;
+
+import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class RecordStreamCipherTest {
 
@@ -74,4 +80,172 @@ public class RecordStreamCipherTest {
         }
     }
 
+    @Test
+    public void calculateMacSHA() throws CryptoException {
+        context.setConnection(new OutboundConnection());
+        context.setSelectedCipherSuite(CipherSuite.TLS_RSA_WITH_RC4_128_SHA);
+        context.setSelectedProtocolVersion(ProtocolVersion.TLS10);
+
+        byte[] data = ArrayConverter
+                .hexStringToByteArray("01010101010101010101010101010101");
+
+        KeySet keySet = new KeySet();
+        keySet.setClientWriteKey(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
+        keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
+        keySet.setClientWriteIv(new byte[8]);
+        keySet.setServerWriteIv(new byte[8]); // ServerSide is not used
+        keySet.setServerWriteKey(new byte[16]); // ServerSide is not used
+        keySet.setServerWriteMacSecret(new byte[20]); // ServerSide is not used
+
+        RecordStreamCipher cipher = new RecordStreamCipher(context,
+                keySet);
+
+        assertArrayEquals(ArrayConverter
+                        .hexStringToByteArray("740b1374aac883ec9171730684b9f7bf84c56cc1"),
+                cipher.calculateMac(data, context.getTalkingConnectionEndType()));
+
+        context.setConnection(new InboundConnection());
+        cipher = new RecordStreamCipher(context, keySet);
+
+        assertArrayEquals(ArrayConverter
+                        .hexStringToByteArray("740b1374aac883ec9171730684b9f7bf84c56cc1"),
+                cipher.calculateMac(data, context.getTalkingConnectionEndType()));
+    }
+
+
+    @Test
+    public void testEncryptTLSv10() throws CryptoException, NoSuchAlgorithmException {
+        /* Outbound for Clients, Inbound for Servers */
+        context.setConnection(new OutboundConnection());
+        /* Sets the Ciphersuit for the Handshake */
+        context.setSelectedCipherSuite(CipherSuite.TLS_RSA_WITH_RC4_128_SHA);
+        /* Sets the SSL/TLS version */
+        context.setSelectedProtocolVersion(ProtocolVersion.TLS10);
+
+        /* Sets the data that should be encrypted later */
+        byte[] data = ArrayConverter
+                .hexStringToByteArray("01010101010101010101010101010101");
+
+        /* Sets a new keySet
+        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
+        KeySet keySet = new KeySet();
+        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
+        * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
+        * rc4 can have a key length from 40 bit up to 256 bit
+        * First we're generating the keys for RC4 with SHA*/
+        keySet.setClientWriteKey(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
+        /*The key length for HMAC-SHA are 20 bytes*/
+        keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
+        keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
+        keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
+        keySet.setServerWriteKey(new byte[16]);         // ServerSide is not used
+        keySet.setServerWriteMacSecret(new byte[20]);   // ServerSide is not used
+
+        RecordStreamCipher cipher = new RecordStreamCipher(context,
+                keySet);
+
+        Record record = new Record();
+        record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
+        record.prepareComputations();
+        /* sequence numbers are 64-bits long */
+        record.setSequenceNumber(new BigInteger("0"));
+        record.setProtocolVersion(ProtocolVersion.TLS10.getValue());
+        record.setCleanProtocolMessageBytes(data);
+
+        /* the cipher is computed over the plaintext(data) and the mac
+        * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
+        cipher.encrypt(record);
+        System.out.println(record.getComputations().getAuthenticatedMetaData());
+
+        /* checks the meta data of the record
+        * the MAC is computed from the MAC secret,
+        * the sequence number,                  00 00 00 00 00 00 00 00 ---+
+        * the type field,                                            16 ---+
+        * the protocol version,                                   03 01 ---+---> authenticated meta data +---+
+        * the message length,                                     00 10 ---+                                 |
+        * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 +---+---> HMAC ---> hash
+        * and two fixed character strings                                                  opad and ipad +---+
+        *  .*/
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603010010"), record.getComputations()
+                .getAuthenticatedMetaData().getValue());
+
+        assertArrayEquals(ArrayConverter
+                        .hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef78fa0cb307f1e7b1beef68fa824907314075768e4"),
+                record.getComputations().getCiphertext().getValue());
+
+
+    }
+
+    @Test
+    public void testDecryptTLSv10() throws CryptoException {
+        context.setConnection(new InboundConnection());
+        context.setSelectedCipherSuite(CipherSuite.TLS_RSA_WITH_RC4_128_SHA);
+        context.setSelectedProtocolVersion(ProtocolVersion.TLS10);
+
+        byte[] data = ArrayConverter
+                .hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef78fa0cb307f1e7b1beef68fa824907314075768e4");
+
+        KeySet keySet = new KeySet();
+        keySet.setClientWriteKey(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
+        keySet.setClientWriteMacSecret(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
+        keySet.setClientWriteIv(new byte[8]);
+        keySet.setServerWriteIv(new byte[8]); // ServerSide is not used
+        keySet.setServerWriteKey(new byte[16]); // ServerSide is not used
+        keySet.setServerWriteMacSecret(new byte[20]); // ServerSide is not used
+
+        RecordStreamCipher plaintext = new RecordStreamCipher(context,
+                keySet);
+
+        Record record = new Record();
+        record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
+        record.prepareComputations();
+        record.setSequenceNumber(new BigInteger("0"));
+        record.setProtocolVersion(ProtocolVersion.TLS10.getValue());
+        record.setProtocolMessageBytes(data);
+
+
+
+        plaintext.decrypt(record);
+
+        assertArrayEquals(ArrayConverter
+                        .hexStringToByteArray("01010101010101010101010101010101"),
+                record.getCleanProtocolMessageBytes().getValue());
+    }
+
+    @Test
+    public void calculateMacMD5() throws CryptoException {
+        context.setConnection(new OutboundConnection());
+        context.setSelectedCipherSuite(CipherSuite.TLS_RSA_WITH_RC4_128_MD5);
+        context.setSelectedProtocolVersion(ProtocolVersion.TLS10);
+
+        byte[] data = ArrayConverter
+                .hexStringToByteArray("01010101010101010101010101010101");
+
+        KeySet keySet = new KeySet();
+        keySet.setClientWriteKey(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
+        keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
+        keySet.setClientWriteIv(new byte[8]);
+        keySet.setServerWriteIv(new byte[8]); // ServerSide is not used
+        keySet.setServerWriteKey(new byte[16]); // ServerSide is not used
+        keySet.setServerWriteMacSecret(new byte[20]); // ServerSide is not used
+
+        RecordStreamCipher cipher = new RecordStreamCipher(context,
+                keySet);
+
+        assertArrayEquals(ArrayConverter
+                        .hexStringToByteArray("6af39a238e82675131e6a383f801674e"),
+                cipher.calculateMac(data, context.getTalkingConnectionEndType()));
+
+        context.setConnection(new InboundConnection());
+        cipher = new RecordStreamCipher(context, keySet);
+
+        assertArrayEquals(ArrayConverter
+                        .hexStringToByteArray("6af39a238e82675131e6a383f801674e"),
+                cipher.calculateMac(data, context.getTalkingConnectionEndType()));
+    }
 }

--- a/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/record/cipher/RecordStreamCipherTest.java
+++ b/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/record/cipher/RecordStreamCipherTest.java
@@ -51,10 +51,10 @@ public class RecordStreamCipherTest {
     @Test
     public void testConstructors() throws NoSuchAlgorithmException, CryptoException {
         // This test just checks that the init() method will not break
-        context.setClientRandom(new byte[] { 0 });
-        context.setServerRandom(new byte[] { 0 });
-        context.setMasterSecret(new byte[] { 0 });
-        AliasedConnection[] connections = new AliasedConnection[] { new InboundConnection(), new OutboundConnection() };
+        context.setClientRandom(new byte[]{0});
+        context.setServerRandom(new byte[]{0});
+        context.setMasterSecret(new byte[]{0});
+        AliasedConnection[] connections = new AliasedConnection[]{new InboundConnection(), new OutboundConnection()};
         for (CipherSuite suite : CipherSuite.values()) {
             if (!suite.isGrease() && !suite.isSCSV() && !suite.name().contains("WITH_NULL_NULL")
                     && !suite.name().contains("CHACHA20_POLY1305") && !suite.name().contains("RABBIT")
@@ -113,109 +113,6 @@ public class RecordStreamCipherTest {
                 cipher.calculateMac(data, context.getTalkingConnectionEndType()));
     }
 
-
-    @Test
-    public void testEncryptTLSv10() throws CryptoException, NoSuchAlgorithmException {
-        /* Outbound for Clients, Inbound for Servers */
-        context.setConnection(new OutboundConnection());
-        /* Sets the Ciphersuit for the Handshake */
-        context.setSelectedCipherSuite(CipherSuite.TLS_RSA_WITH_RC4_128_SHA);
-        /* Sets the SSL/TLS version */
-        context.setSelectedProtocolVersion(ProtocolVersion.TLS10);
-
-        /* Sets the data that should be encrypted later */
-        byte[] data = ArrayConverter
-                .hexStringToByteArray("01010101010101010101010101010101");
-
-        /* Sets a new keySet
-        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
-        KeySet keySet = new KeySet();
-        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
-        * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
-        * rc4 can have a key length from 40 bit up to 256 bit
-        * First we're generating the keys for RC4 with SHA*/
-        keySet.setClientWriteKey(ArrayConverter
-                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
-        /*The key length for HMAC-SHA are 20 bytes*/
-        keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
-        keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
-        keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
-        keySet.setServerWriteKey(new byte[16]);         // ServerSide is not used
-        keySet.setServerWriteMacSecret(new byte[20]);   // ServerSide is not used
-
-        RecordStreamCipher cipher = new RecordStreamCipher(context,
-                keySet);
-
-        Record record = new Record();
-        record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
-        record.prepareComputations();
-        /* sequence numbers are 64-bits long */
-        record.setSequenceNumber(new BigInteger("0"));
-        record.setProtocolVersion(ProtocolVersion.TLS10.getValue());
-        record.setCleanProtocolMessageBytes(data);
-
-        /* the cipher is computed over the plaintext(data) and the mac
-        * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
-        cipher.encrypt(record);
-        System.out.println(record.getComputations().getAuthenticatedMetaData());
-
-        /* checks the meta data of the record
-        * the MAC is computed from the MAC secret,
-        * the sequence number,                  00 00 00 00 00 00 00 00 ---+
-        * the type field,                                            16 ---+
-        * the protocol version,                                   03 01 ---+---> authenticated meta data +---+
-        * the message length,                                     00 10 ---+                                 |
-        * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 +---+---> HMAC ---> hash
-        * and two fixed character strings                                                  opad and ipad +---+
-        *  .*/
-        assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603010010"), record.getComputations()
-                .getAuthenticatedMetaData().getValue());
-
-        assertArrayEquals(ArrayConverter
-                        .hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef78fa0cb307f1e7b1beef68fa824907314075768e4"),
-                record.getComputations().getCiphertext().getValue());
-
-
-    }
-
-    @Test
-    public void testDecryptTLSv10() throws CryptoException {
-        context.setConnection(new InboundConnection());
-        context.setSelectedCipherSuite(CipherSuite.TLS_RSA_WITH_RC4_128_SHA);
-        context.setSelectedProtocolVersion(ProtocolVersion.TLS10);
-
-        byte[] data = ArrayConverter
-                .hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef78fa0cb307f1e7b1beef68fa824907314075768e4");
-
-        KeySet keySet = new KeySet();
-        keySet.setClientWriteKey(ArrayConverter
-                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
-        keySet.setClientWriteMacSecret(ArrayConverter
-                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
-        keySet.setClientWriteIv(new byte[8]);
-        keySet.setServerWriteIv(new byte[8]); // ServerSide is not used
-        keySet.setServerWriteKey(new byte[16]); // ServerSide is not used
-        keySet.setServerWriteMacSecret(new byte[20]); // ServerSide is not used
-
-        RecordStreamCipher plaintext = new RecordStreamCipher(context,
-                keySet);
-
-        Record record = new Record();
-        record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
-        record.prepareComputations();
-        record.setSequenceNumber(new BigInteger("0"));
-        record.setProtocolVersion(ProtocolVersion.TLS10.getValue());
-        record.setProtocolMessageBytes(data);
-
-
-
-        plaintext.decrypt(record);
-
-        assertArrayEquals(ArrayConverter
-                        .hexStringToByteArray("01010101010101010101010101010101"),
-                record.getCleanProtocolMessageBytes().getValue());
-    }
-
     @Test
     public void calculateMacMD5() throws CryptoException {
         context.setConnection(new OutboundConnection());
@@ -247,5 +144,403 @@ public class RecordStreamCipherTest {
         assertArrayEquals(ArrayConverter
                         .hexStringToByteArray("6af39a238e82675131e6a383f801674e"),
                 cipher.calculateMac(data, context.getTalkingConnectionEndType()));
+    }
+
+    @Test
+    public void testEncryptTLSv10SHA() throws CryptoException, NoSuchAlgorithmException {
+        /* Outbound for Clients, Inbound for Servers */
+        context.setConnection(new OutboundConnection());
+        /* Sets the Ciphersuit for the Handshake */
+        context.setSelectedCipherSuite(CipherSuite.TLS_RSA_WITH_RC4_128_SHA);
+        /* Sets the SSL/TLS version */
+        context.setSelectedProtocolVersion(ProtocolVersion.TLS10);
+
+        /* Sets the data that should be encrypted later */
+        byte[] data = ArrayConverter
+                .hexStringToByteArray("01010101010101010101010101010101");
+
+        /* Sets a new keySet
+        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
+        KeySet keySet = new KeySet();
+        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
+         * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
+         * rc4 can have a key length from 40 bit up to 256 bit
+         * First we're generating the keys for RC4 with SHA*/
+        keySet.setClientWriteKey(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
+        /*The key length for HMAC-SHA are 20 bytes*/
+        keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
+        keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
+        keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
+        keySet.setServerWriteKey(new byte[16]);         // ServerSide is not used
+        keySet.setServerWriteMacSecret(new byte[20]);   // ServerSide is not used
+
+        RecordStreamCipher cipher = new RecordStreamCipher(context,
+                keySet);
+
+        Record record = new Record();
+        record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
+        record.prepareComputations();
+        /* sequence numbers are 64-bits long */
+        record.setSequenceNumber(new BigInteger("0"));
+        record.setProtocolVersion(ProtocolVersion.TLS10.getValue());
+        record.setCleanProtocolMessageBytes(data);
+
+        /* the cipher is computed over the plaintext(data) and the mac
+         * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
+        cipher.encrypt(record);
+
+        /* tests the meta data of the record
+         * the MAC is computed from the MAC secret,
+         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
+         * the type field,                                            16 ---+
+         * the protocol version,                                   03 01 ---+---> authenticated meta data ---+
+         * the message length,                                     00 10 ---+                                |
+         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
+         * and two fixed character strings                                                  opad and ipad ---+
+         *  .*/
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603010010"), record.getComputations()
+                .getAuthenticatedMetaData().getValue());
+
+        /* tests the encryption key */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"),
+                record.getComputations().getCipherKey().getValue());
+
+        /* tests the mac key */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"),
+                record.getComputations().getMacKey().getValue());
+
+        /* tests the mac only*/
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("eaed6e296a5cdface7557c18873e42ea42c44df8"), record
+                .getComputations().getMac().getValue());
+
+        /* tests the given plaintext + mac of the plaintext */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("01010101010101010101010101010101eaed6e296a5cdface7557c18873e42ea42c44df8"),
+                record.getComputations().getPlainRecordBytes().getValue());
+
+        /* tests the encryption */
+        assertArrayEquals(ArrayConverter
+                        .hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef78fa0cb307f1e7b1beef68fa824907314075768e4"),
+                record.getComputations().getCiphertext().getValue());
+
+        /* tests protocol message bytes encrypted */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef78fa0cb307f1e7b1beef68fa824907314075768e4"),
+                record.getProtocolMessageBytes().getValue());
+    }
+
+    @Test
+    public void testDecryptTLSv10SHA() throws CryptoException {
+        context.setConnection(new InboundConnection());
+        context.setSelectedCipherSuite(CipherSuite.TLS_RSA_WITH_RC4_128_SHA);
+        context.setSelectedProtocolVersion(ProtocolVersion.TLS10);
+
+        byte[] data = ArrayConverter
+                .hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef78fa0cb307f1e7b1beef68fa824907314075768e4");
+
+        KeySet keySet = new KeySet();
+        keySet.setClientWriteKey(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
+        keySet.setClientWriteMacSecret(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
+        keySet.setClientWriteIv(new byte[8]);
+        keySet.setServerWriteIv(new byte[8]); // ServerSide is not used
+        keySet.setServerWriteKey(new byte[16]); // ServerSide is not used
+        keySet.setServerWriteMacSecret(new byte[20]); // ServerSide is not used
+
+        RecordStreamCipher plaintext = new RecordStreamCipher(context,
+                keySet);
+
+        Record record = new Record();
+        record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
+        record.prepareComputations();
+        record.setSequenceNumber(new BigInteger("0"));
+        record.setProtocolVersion(ProtocolVersion.TLS10.getValue());
+        record.setProtocolMessageBytes(data);
+
+        plaintext.decrypt(record);
+
+        /* tests the meta data of the record
+         * the MAC is computed from the MAC secret,
+         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
+         * the type field,                                            16 ---+
+         * the protocol version,                                   03 01 ---+---> authenticated meta data ---+
+         * the message length,                                     00 10 ---+                                |
+         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
+         * and two fixed character strings                                                  opad and ipad ---+
+         *  .*/
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603010010"), record.getComputations()
+                .getAuthenticatedMetaData().getValue());
+
+        /* tests the decryption key */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"),
+                record.getComputations().getCipherKey().getValue());
+
+        /* tests the mac key */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"),
+                record.getComputations().getMacKey().getValue());
+
+        /* tests the decryption only */
+        assertArrayEquals(ArrayConverter
+                        .hexStringToByteArray("01010101010101010101010101010101"),
+                record.getCleanProtocolMessageBytes().getValue());
+
+        /* tests the mac only*/
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("eaed6e296a5cdface7557c18873e42ea42c44df8"), record
+                .getComputations().getMac().getValue());
+
+        /* tests the given plaintext + mac of the plaintext */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("01010101010101010101010101010101eaed6e296a5cdface7557c18873e42ea42c44df8"),
+                record.getComputations().getPlainRecordBytes().getValue());
+
+        /* tests protocol message bytes encrypted */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef78fa0cb307f1e7b1beef68fa824907314075768e4"),
+                record.getProtocolMessageBytes().getValue());
+    }
+
+    @Test
+    public void testEncryptTLSv10MD5() throws CryptoException, NoSuchAlgorithmException {
+        /* Outbound for Clients, Inbound for Servers */
+        context.setConnection(new OutboundConnection());
+        /* Sets the Ciphersuit for the Handshake */
+        context.setSelectedCipherSuite(CipherSuite.TLS_RSA_WITH_RC4_128_MD5);
+        /* Sets the SSL/TLS version */
+        context.setSelectedProtocolVersion(ProtocolVersion.TLS10);
+
+        /* Sets the data that should be encrypted later */
+        byte[] data = ArrayConverter
+                .hexStringToByteArray("01010101010101010101010101010101");
+
+        /* Sets a new keySet
+        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
+        KeySet keySet = new KeySet();
+        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
+         * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
+         * rc4 can have a key length from 40 bit up to 256 bit
+         * First we're generating the keys for RC4 with SHA*/
+        keySet.setClientWriteKey(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
+        /*The key length for HMAC-SHA are 20 bytes*/
+        keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
+        keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
+        keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
+        keySet.setServerWriteKey(new byte[16]);         // ServerSide is not used
+        keySet.setServerWriteMacSecret(new byte[20]);   // ServerSide is not used
+
+        RecordStreamCipher cipher = new RecordStreamCipher(context,
+                keySet);
+
+        Record record = new Record();
+        record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
+        record.prepareComputations();
+        /* sequence numbers are 64-bits long */
+        record.setSequenceNumber(new BigInteger("0"));
+        record.setProtocolVersion(ProtocolVersion.TLS10.getValue());
+        record.setCleanProtocolMessageBytes(data);
+
+        /* the cipher is computed over the plaintext(data) and the mac
+         * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
+        cipher.encrypt(record);
+
+        /* tests the meta data of the record
+         * the MAC is computed from the MAC secret,
+         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
+         * the type field,                                            16 ---+
+         * the protocol version,                                   03 01 ---+---> authenticated meta data ---+
+         * the message length,                                     00 10 ---+                                |
+         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
+         * and two fixed character strings                                                  opad and ipad ---+
+         *  .*/
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603010010"), record.getComputations()
+                .getAuthenticatedMetaData().getValue());
+
+        /* tests the encryption key */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"),
+                record.getComputations().getCipherKey().getValue());
+
+        /* tests the mac key */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"),
+                record.getComputations().getMacKey().getValue());
+
+        /* tests the mac only*/
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("a7ade7c77687ac136ee4a2af76713c2b"), record
+                .getComputations().getMac().getValue());
+
+        /* tests the given plaintext + mac of the plaintext */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("01010101010101010101010101010101a7ade7c77687ac136ee4a2af76713c2b"),
+                record.getComputations().getPlainRecordBytes().getValue());
+
+        /* tests the encryption */
+        assertArrayEquals(ArrayConverter
+                        .hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef7c2e042de63c508a46747511fd5df0dd5"),
+                record.getComputations().getCiphertext().getValue());
+
+        /* tests protocol message bytes encrypted */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef7c2e042de63c508a46747511fd5df0dd5"),
+                record.getProtocolMessageBytes().getValue());
+    }
+
+    @Test
+    public void testDecryptTLSv10MD5() throws CryptoException {
+        context.setConnection(new InboundConnection());
+        context.setSelectedCipherSuite(CipherSuite.TLS_RSA_WITH_RC4_128_MD5);
+        context.setSelectedProtocolVersion(ProtocolVersion.TLS10);
+
+        byte[] data = ArrayConverter
+                .hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef7c2e042de63c508a46747511fd5df0dd5");
+
+        KeySet keySet = new KeySet();
+        keySet.setClientWriteKey(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
+        keySet.setClientWriteMacSecret(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
+        keySet.setClientWriteIv(new byte[8]);
+        keySet.setServerWriteIv(new byte[8]); // ServerSide is not used
+        keySet.setServerWriteKey(new byte[16]); // ServerSide is not used
+        keySet.setServerWriteMacSecret(new byte[20]); // ServerSide is not used
+
+        RecordStreamCipher plaintext = new RecordStreamCipher(context,
+                keySet);
+
+        Record record = new Record();
+        record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
+        record.prepareComputations();
+        record.setSequenceNumber(new BigInteger("0"));
+        record.setProtocolVersion(ProtocolVersion.TLS10.getValue());
+        record.setProtocolMessageBytes(data);
+
+        plaintext.decrypt(record);
+
+        /* tests the meta data of the record
+         * the MAC is computed from the MAC secret,
+         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
+         * the type field,                                            16 ---+
+         * the protocol version,                                   03 01 ---+---> authenticated meta data ---+
+         * the message length,                                     00 10 ---+                                |
+         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
+         * and two fixed character strings                                                  opad and ipad ---+
+         *  .*/
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("00000000000000001603010010"), record.getComputations()
+                .getAuthenticatedMetaData().getValue());
+
+        /* tests the decryption key */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"),
+                record.getComputations().getCipherKey().getValue());
+
+        /* tests the mac key */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"),
+                record.getComputations().getMacKey().getValue());
+
+        /* tests the decryption only */
+        assertArrayEquals(ArrayConverter
+                        .hexStringToByteArray("01010101010101010101010101010101"),
+                record.getCleanProtocolMessageBytes().getValue());
+
+        /* tests the mac only*/
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("a7ade7c77687ac136ee4a2af76713c2b"), record
+                .getComputations().getMac().getValue());
+
+        /* tests the given plaintext + mac of the plaintext */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("01010101010101010101010101010101a7ade7c77687ac136ee4a2af76713c2b"),
+                record.getComputations().getPlainRecordBytes().getValue());
+
+        /* tests protocol message bytes encrypted */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef7c2e042de63c508a46747511fd5df0dd5"),
+                record.getProtocolMessageBytes().getValue());
+    }
+
+    @Test
+    public void testEncryptSSL310SHA() throws CryptoException, NoSuchAlgorithmException {
+        /* Outbound for Clients, Inbound for Servers */
+        context.setConnection(new OutboundConnection());
+        /* Sets the Ciphersuit for the Handshake */
+        context.setSelectedCipherSuite(CipherSuite.TLS_RSA_WITH_RC4_128_SHA);
+        /* Sets the SSL/TLS version */
+        context.setSelectedProtocolVersion(ProtocolVersion.SSL3);
+
+        /* Sets the data that should be encrypted later */
+        byte[] data = ArrayConverter
+                .hexStringToByteArray("01010101010101010101010101010101");
+
+        /* Sets a new keySet
+        a keySet contains the negotiated keys out of the pseudorandom bit stream*/
+        KeySet keySet = new KeySet();
+        /* Since we're on the client side we're setting EncWriteClient and MacWriteClient only
+         * Note that we have to consider the key length for the rc4 cipher since it can be used with different lengths
+         * rc4 can have a key length from 40 bit up to 256 bit
+         * First we're generating the keys for RC4 with SHA*/
+        keySet.setClientWriteKey(ArrayConverter
+                .hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"));
+        /*The key length for HMAC-SHA are 20 bytes*/
+        keySet.setClientWriteMacSecret(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"));
+        keySet.setClientWriteIv(new byte[8]);           // RC4 is not a block cipher so we don't need an iv
+        keySet.setServerWriteIv(new byte[8]);           // ServerSide is not used
+        keySet.setServerWriteKey(new byte[16]);         // ServerSide is not used
+        keySet.setServerWriteMacSecret(new byte[20]);   // ServerSide is not used
+
+        RecordStreamCipher cipher = new RecordStreamCipher(context,
+                keySet);
+
+        Record record = new Record();
+        record.setContentType(ProtocolMessageType.HANDSHAKE.getValue());
+        record.prepareComputations();
+        /* sequence numbers are 64-bits long */
+        record.setSequenceNumber(new BigInteger("0"));
+        record.setProtocolVersion(ProtocolVersion.SSL3.getValue());
+        record.setCleanProtocolMessageBytes(data);
+
+        /* the cipher is computed over the plaintext(data) and the mac
+         * the mac is computed over the AuthenticatedMetaData + plaintext + LocalConnectionEndType*/
+        cipher.encrypt(record);
+
+        /* tests the meta data of the record
+        the MAC is computed
+   from the MAC secret, the sequence number, the message length, the
+   message contents, and two fixed-character strings.  The message type
+   field is necessary to ensure that messages intended for one SSL
+   record layer client are not redirected to another.  The sequence
+   number ensures that attempts to delete or reorder messages will be
+   detected.  Since sequence numbers are 64 bits long, they should never
+   overflow.  Messages from one party cannot be inserted into the
+   other's output, since they use independent MAC secrets.  Similarly,
+   the server-write and client-write keys are independent so stream
+   cipher keys are used only once.
+         * the MAC is computed from the MAC secret,
+         * the sequence number,                  00 00 00 00 00 00 00 00 ---+
+         * the type field,                                            16 ---+
+         * the protocol version,                                   00 10 ---+---> authenticated meta data ---+
+         * the message length,                                                                               |
+         * the message contents,                          01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 01 ---+---> HMAC ---> hash
+         * and two fixed character strings                                                  opad and ipad ---+
+         *  .*/
+        System.out.println(record.getComputations().getAuthenticatedMetaData());
+        System.out.println(record.getComputations().getAuthenticatedNonMetaData());
+        System.out.println(record.getCleanProtocolMessageBytes());
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("0000000000000000160010"), record.getComputations()
+                .getAuthenticatedMetaData().getValue());
+
+        /* tests the encryption key */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEF"),
+                record.getComputations().getCipherKey().getValue());
+
+        /* tests the mac key */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("DEADBEEFC0FEDEADBEEFC0FEDEADBEEFC0FEDEAD"),
+                record.getComputations().getMacKey().getValue());
+
+        /* tests the mac only*/
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("740b1374aac883ec9171730684b9f7bf84c56cc1"), record
+                .getComputations().getMac().getValue());
+
+        /* tests the given plaintext + mac of the plaintext */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("010101010101010101010101010101017e9f01ddf2c70841a74f087e82bfe2e90e8d12ec"),
+                record.getComputations().getPlainRecordBytes().getValue());
+
+        /* tests the encryption */
+        assertArrayEquals(ArrayConverter
+                        .hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef71bd2a4c4e785acf6aeecfbce2111d3174b1e37f0"),
+                record.getComputations().getCiphertext().getValue());
+
+        /* tests protocol message bytes encrypted */
+        assertArrayEquals(ArrayConverter.hexStringToByteArray("805264444f48ea5b98a0ceb3884c2ef71bd2a4c4e785acf6aeecfbce2111d3174b1e37f0"),
+                record.getProtocolMessageBytes().getValue());
     }
 }


### PR DESCRIPTION

This pull request includes changes made in the RecordStreamCipherTest class.
Test methods for the encrypt and decrypt methods of the RecordStreamCipher class were implemented.
Those test methods testing the encryption and decryption of a record with the rc4 stream cipher for all ssl/tls versions from ssl version 2 up to tls version 1.3.

In addition to that the, calculateMacSHA and calculateMacMD5 test methods testing the calculateMac method of the RecordStreamCipher class.