### PR TITLE
Fixed interpretation of FFDHE key share byte values

### DIFF
--- a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/crypto/KeyShareCalculator.java
+++ b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/crypto/KeyShareCalculator.java
@@ -96,7 +96,7 @@ public class KeyShareCalculator {
             }
         } else {
             FFDHEGroup ffdheGroup = GroupFactory.getGroup(group);
-            BigInteger sharedElement = new BigInteger(publicKey).modPow(privateKey.abs(), ffdheGroup.getP().abs());
+            BigInteger sharedElement = new BigInteger(1, publicKey).modPow(privateKey.abs(), ffdheGroup.getP().abs());
             return ArrayConverter.bigIntegerToNullPaddedByteArray(sharedElement,
                 ffdheGroup.getP().bitLength() / Bits.IN_A_BYTE);
         }


### PR DESCRIPTION
Contains the fix for #126 suggested by @SidolFreiburg