### PR TITLE
Fixed wrong key usage for finish message when using early data

### DIFF
--- a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/context/TlsContext.java
+++ b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/context/TlsContext.java
@@ -31,6 +31,7 @@ import de.rub.nds.tlsattacker.core.protocol.message.extension.statusrequestv2.Re
 import de.rub.nds.tlsattacker.core.protocol.message.extension.trustedauthority.TrustedAuthority;
 import de.rub.nds.tlsattacker.core.record.Record;
 import de.rub.nds.tlsattacker.core.record.cipher.RecordNullCipher;
+import de.rub.nds.tlsattacker.core.record.cipher.cryptohelper.KeySet;
 import de.rub.nds.tlsattacker.core.state.Context;
 import de.rub.nds.tlsattacker.core.state.Keylogfile;
 import de.rub.nds.tlsattacker.core.state.session.IdSession;
@@ -70,6 +71,9 @@ public class TlsContext extends LayerContext {
 
     /** Early traffic secret used to encrypt early data. */
     private byte[] clientEarlyTrafficSecret;
+
+    /** Handshake traffic secret in case it needs to be precalculated during early data * */
+    private KeySet keySetHandshake;
 
     /** CipherSuite used for early data. */
     private CipherSuite earlyDataCipherSuite;
@@ -1745,6 +1749,20 @@ public class TlsContext extends LayerContext {
 
     public void setUseExtendedMasterSecret(boolean useExtendedMasterSecret) {
         this.useExtendedMasterSecret = useExtendedMasterSecret;
+    }
+
+    /**
+     * @return the keySetHandshake
+     */
+    public KeySet getkeySetHandshake() {
+        return keySetHandshake;
+    }
+
+    /**
+     * @param keySetHandshake the keySetHandshake to set
+     */
+    public void setkeySetHandshake(KeySet keySetHandshake) {
+        this.keySetHandshake = keySetHandshake;
     }
 
     /**

--- a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/protocol/handler/EndOfEarlyDataHandler.java
+++ b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/protocol/handler/EndOfEarlyDataHandler.java
@@ -9,16 +9,11 @@
 package de.rub.nds.tlsattacker.core.protocol.handler;
 
 import de.rub.nds.tlsattacker.core.constants.Tls13KeySetType;
-import de.rub.nds.tlsattacker.core.exceptions.CryptoException;
-import de.rub.nds.tlsattacker.core.exceptions.WorkflowExecutionException;
 import de.rub.nds.tlsattacker.core.layer.context.TlsContext;
 import de.rub.nds.tlsattacker.core.protocol.message.EndOfEarlyDataMessage;
-import de.rub.nds.tlsattacker.core.record.cipher.RecordCipher;
 import de.rub.nds.tlsattacker.core.record.cipher.RecordCipherFactory;
 import de.rub.nds.tlsattacker.core.record.cipher.cryptohelper.KeySet;
-import de.rub.nds.tlsattacker.core.record.cipher.cryptohelper.KeySetGenerator;
 import de.rub.nds.tlsattacker.transport.ConnectionEndType;
-import java.security.NoSuchAlgorithmException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -32,26 +27,48 @@ public class EndOfEarlyDataHandler extends HandshakeMessageHandler<EndOfEarlyDat
 
     @Override
     public void adjustContext(EndOfEarlyDataMessage message) {
-        if (tlsContext.getChooser().getConnectionEndType() == ConnectionEndType.SERVER) {
-            adjustClientCipherAfterEarly();
+        // nothing to adjust
+    }
+
+    @Override
+    public void adjustContextAfterSerialize(EndOfEarlyDataMessage message) {
+        if (tlsContext.getChooser().getSelectedProtocolVersion().isTLS13()) {
+            setClientRecordCipher();
+            setServertRecordCipher();
         }
     }
 
-    private void adjustClientCipherAfterEarly() {
-        try {
-            tlsContext.setActiveClientKeySetType(Tls13KeySetType.HANDSHAKE_TRAFFIC_SECRETS);
-            LOGGER.debug("Setting cipher for client to use handshake secrets");
-            KeySet clientKeySet =
-                    KeySetGenerator.generateKeySet(
-                            tlsContext,
-                            tlsContext.getChooser().getSelectedProtocolVersion(),
-                            tlsContext.getActiveClientKeySetType());
-            RecordCipher recordCipherClient =
-                    RecordCipherFactory.getRecordCipher(tlsContext, clientKeySet, false);
-            tlsContext.getRecordLayer().updateDecryptionCipher(recordCipherClient);
-        } catch (CryptoException | NoSuchAlgorithmException ex) {
-            LOGGER.error("Generating KeySet failed", ex);
-            throw new WorkflowExecutionException(ex);
+    private void setClientRecordCipher() {
+        tlsContext.setActiveClientKeySetType(Tls13KeySetType.HANDSHAKE_TRAFFIC_SECRETS);
+        KeySet keySet = tlsContext.getkeySetHandshake();
+
+        if (tlsContext.getChooser().getConnectionEndType() == ConnectionEndType.SERVER) {
+            tlsContext
+                    .getRecordLayer()
+                    .updateDecryptionCipher(
+                            RecordCipherFactory.getRecordCipher(tlsContext, keySet, false));
+        } else {
+            tlsContext
+                    .getRecordLayer()
+                    .updateEncryptionCipher(
+                            RecordCipherFactory.getRecordCipher(tlsContext, keySet, true));
+        }
+    }
+
+    private void setServertRecordCipher() {
+        tlsContext.setActiveClientKeySetType(Tls13KeySetType.HANDSHAKE_TRAFFIC_SECRETS);
+        KeySet keySet = tlsContext.getkeySetHandshake();
+
+        if (tlsContext.getChooser().getConnectionEndType() == ConnectionEndType.SERVER) {
+            tlsContext
+                    .getRecordLayer()
+                    .updateDecryptionCipher(
+                            RecordCipherFactory.getRecordCipher(tlsContext, keySet, true));
+        } else {
+            tlsContext
+                    .getRecordLayer()
+                    .updateEncryptionCipher(
+                            RecordCipherFactory.getRecordCipher(tlsContext, keySet, false));
         }
     }
 }


### PR DESCRIPTION
When I used TLS-Attacker in client mode for testing early data, I found that the server side couldn't decrypt the Finished Message in the second handshake.

**How to reproduce**
1. Start server: `openssl s_server -cert ./server_cert.pem -key ./server_key.pem -tls1_3 -early_data -no_anti_replay -trace`
    - hint: -anit_replay is only active because the client won't close the connection with close_notify and I want to prevent that s_server is throwing away the session information
2. Start TLS-Attacker client: `java -jar ./apps/TLS-Client.jar -connect localhost:4433 -config ./tls13_0rtt_short.txt`
[tls13_0rtt_short.txt](https://github.com/user-attachments/files/16437708/tls13_0rtt_short.txt)

Error on server side: 
```shell
ERROR
80609AF601000000:error:0A000119:SSL routines:tls_get_more_records:decryption failed or bad record mac:ssl/record/methods/tls_common.c:859:
80609AF601000000:error:0A000139:SSL routines::record layer failure:ssl/record/rec_layer_s3.c:650:
shutting down SSL
CONNECTION CLOSED
```

After some digging I think I found the root cause. The Finished message is encrypted with the same key as the EndOfEarlyData message. To see this, you can put
```java
System.out.println(
    "Key used for encryption: "
    + Arrays.toString(
        getState().getKeySet().getWriteKey(getConnectionEndType())
));
``` 
at the beginning of `public void encrypt(Record record) throws CryptoException { }` in "TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/record/cipher/RecordAEADCipher.java"
But EndOfEarlyData message needs to be encrypted under client_early_traffic_secret and the Finished message with client_handshake_traffic_secret (compare RFC8446, chapter [4.5](https://datatracker.ietf.org/doc/html/rfc8446#section-4.5) and [7.3](https://datatracker.ietf.org/doc/html/rfc8446#section-7.3)).

---
I implemented a rough workaround to fix the client behavior in the second handshake flow. Roughly speaking, at the point where the client receives the server's Finish message, we precalculate the handshake_traffic_secret and store it in TlsContext (see FinishHandler.java) even though the next secret to be used is early_traffic_secret for sending EndOfEarlyData message.
When this message is sent out, we set the active key set to the stored handshake_traffic_secret so that the following Finish message sent by the client to the server is correctly encrypted (see EndOfEarlyDataHandler.java)

---
Disclaimer: This is working when using TLS-Attacker in client mode but not yet for the server mode. I will update this draft PR accordingly.