### PR TITLE
Implement @overwrite toString() for EndOfEarlyDataMessage

### DIFF
--- a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/protocol/message/EndOfEarlyDataMessage.java
+++ b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/protocol/message/EndOfEarlyDataMessage.java
@@ -46,6 +46,13 @@ public class EndOfEarlyDataMessage extends HandshakeMessage<EndOfEarlyDataMessag
     }
 
     @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("EndOfEarlyDataMessage: <empty>");
+        return sb.toString();
+    }
+
+    @Override
     public String toShortString() {
         return "EOED";
     }

--- a/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/protocol/message/EndOfEarlyDataMessageTest.java
+++ b/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/protocol/message/EndOfEarlyDataMessageTest.java
@@ -1,0 +1,23 @@
+/*
+ * TLS-Attacker - A Modular Penetration Testing Framework for TLS
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.tlsattacker.core.protocol.message;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class EndOfEarlyDataMessageTest extends AbstractMessageTest<EndOfEarlyDataMessage> {
+
+    public EndOfEarlyDataMessageTest() {
+        super(EndOfEarlyDataMessage::new, "EndOfEarlyDataMessage: <empty>");
+    }
+
+    public static Stream<Arguments> provideToStringTestVectors() {
+        return Stream.of(Arguments.of(new Object[] {null}, null));
+    }
+}


### PR DESCRIPTION
Right now printing an EndOfEarlyData Message looks like this:
```
HandshakeMessage:
  Type: null
  Length: null
```

With the `toString()` overwrite it looks like this:
```
EndOfEarlyDataMessage: <empty>
```