### PR TITLE
Remove mention of Attacks.jar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,6 @@ or as a server with:
 $ java -jar TLS-Server.jar -port [port]
 ```
 
-TLS-Attacker also ships with some example attacks on TLS to show you how easy it is to implement an attack with TLS-Attacker.
-You can run those examples with the following command:
-
-```bash
-$ java -jar Attacks.jar [Attack] -connect [host:port]
-```
 
 Although these example applications are very powerful in itself, TLS-Attacker unleashes its full potential when used as a programming library.
 


### PR DESCRIPTION
The module `attacks.jar` doesn't exist anymore (as mentionend in #127), see also The commit 'Removed attacks module' https://github.com/tls-attacker/TLS-Attacker/commit/3039e72797d6f058439879fd5baf62047968f25c

I removed the lines in the README.md that mention it. Hopefully others won't stumble on the same issue as me.


