### PR TITLE
Fix XML example in README for IntegerExplicitValueModification

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,9 +271,9 @@ We can of course use this concept by constructing our TLS workflows. Imagine you
             <Heartbeat>
                 <payloadLength>
                     <modifications>
-                        <IntegerExplicitValueModification>
+                        <integerExplicitValueModification>
                             <explicitValue>20000</explicitValue>
-                        </IntegerExplicitValueModification>
+                        </integerExplicitValueModification>
                     </modifications>
                 </payloadLength>
             </Heartbeat>


### PR DESCRIPTION
## Summary
- Fixed XML element casing from `IntegerExplicitValueModification` to `integerExplicitValueModification` in the README
- The correct casing is required for proper XML parsing in TLS-Client

## Test plan
- [x] Verified the XML example now uses the correct lowercase element name
- [x] Built the project successfully with `mvn clean compile`
- [x] Applied code formatting with `mvn spotless:apply`

Fixes #214