### PR TITLE
Fix: DTLS finishWithCloseNotify override issue (#182)

### DIFF
--- a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/config/delegate/ProtocolVersionDelegate.java
+++ b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/config/delegate/ProtocolVersionDelegate.java
@@ -49,7 +49,6 @@ public class ProtocolVersionDelegate extends Delegate {
             th = TransportHandlerType.UDP;
             config.setDefaultLayerConfiguration(StackConfiguration.DTLS);
             config.setWorkflowExecutorType(WorkflowExecutorType.DTLS);
-            config.setFinishWithCloseNotify(true);
             config.setIgnoreRetransmittedCssInDtls(true);
         }
 

--- a/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/config/delegate/ProtocolVersionDelegateTest.java
+++ b/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/config/delegate/ProtocolVersionDelegateTest.java
@@ -91,4 +91,47 @@ public class ProtocolVersionDelegateTest extends AbstractDelegateTest<ProtocolVe
         delegate.applyDelegate(config);
         assertTrue(EqualsBuilder.reflectionEquals(config, config2, "certificateChainConfig"));
     }
+
+    @Test
+    public void testDTLSDoesNotOverrideFinishWithCloseNotify() {
+        Config config = new Config();
+        // Set finishWithCloseNotify to false explicitly
+        config.setFinishWithCloseNotify(false);
+
+        String[] args = new String[2];
+        args[0] = "-version";
+        args[1] = "DTLS12";
+
+        jcommander.parse(args);
+        delegate.applyDelegate(config);
+
+        // Verify that finishWithCloseNotify remains false and is not overridden
+        assertFalse(config.isFinishWithCloseNotify());
+
+        // Verify other DTLS settings are still applied correctly
+        assertSame(ProtocolVersion.DTLS12, config.getHighestProtocolVersion());
+        assertSame(
+                TransportHandlerType.UDP,
+                config.getDefaultClientConnection().getTransportHandlerType());
+        assertSame(
+                TransportHandlerType.UDP,
+                config.getDefaultServerConnection().getTransportHandlerType());
+    }
+
+    @Test
+    public void testDTLSRespectsTrueFinishWithCloseNotify() {
+        Config config = new Config();
+        // Set finishWithCloseNotify to true explicitly
+        config.setFinishWithCloseNotify(true);
+
+        String[] args = new String[2];
+        args[0] = "-version";
+        args[1] = "DTLS12";
+
+        jcommander.parse(args);
+        delegate.applyDelegate(config);
+
+        // Verify that finishWithCloseNotify remains true
+        assertTrue(config.isFinishWithCloseNotify());
+    }
 }


### PR DESCRIPTION
## Summary
- Removed automatic setting of `finishWithCloseNotify` to true when using `-version DTLS*` parameter
- This allows users to control the `finishWithCloseNotify` setting via configuration file as intended
- Fixes #182

## Details
The issue occurred because the `ProtocolVersionDelegate` was unconditionally setting `finishWithCloseNotify` to true for all DTLS versions, overriding any value set in the configuration file. This made it impossible for users to disable the close notify alert when using DTLS.

The fix is simple: remove the line that sets this value, allowing the configuration file setting to be respected.

## Test plan
- [x] Added unit tests to verify that `finishWithCloseNotify` configuration is respected for DTLS versions
- [x] Tests verify that both `true` and `false` values are preserved when set in config
- [x] All existing tests pass
- [x] Code formatted with spotless