### PR TITLE
Quic server mode fixes

### DIFF
--- a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/impl/QuicFrameLayer.java
+++ b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/impl/QuicFrameLayer.java
@@ -60,6 +60,9 @@ public class QuicFrameLayer
     private long handshakePhaseExpectedCryptoFrameOffset = 0;
     private long applicationPhaseExpectedCryptoFrameOffset = 0;
 
+    private long initialPhaseSendCryptoOffset = 0;
+    private long handshakePhaseSendCryptoOffset = 0;
+
     private List<CryptoFrame> cryptoFrameBuffer = new ArrayList<>();
 
     private boolean hasExperiencedTimeout = false;
@@ -143,7 +146,11 @@ public class QuicFrameLayer
                         packetLayerHint = new QuicPacketLayerHint(QuicPacketType.HANDSHAKE_PACKET);
                     }
                     List<QuicFrame> givenFrames = getUnprocessedConfiguredContainers();
-                    int offset = 0;
+                    int localOffset = 0;
+                    long streamOffset =
+                            hintedFirstMessage
+                                    ? initialPhaseSendCryptoOffset
+                                    : handshakePhaseSendCryptoOffset;
 
                     // Send crypto frames from the configuration (if present)
                     List<CryptoFrame> givenCryptoFrames =
@@ -156,31 +163,40 @@ public class QuicFrameLayer
                                 frame.getMaxFrameLengthConfig() != 0
                                         ? frame.getMaxFrameLengthConfig()
                                         : MAX_FRAME_SIZE;
-                        byte[] payload = Arrays.copyOfRange(data, offset, offset + toCopy);
+                        byte[] payload =
+                                Arrays.copyOfRange(data, localOffset, localOffset + toCopy);
                         frame.setCryptoDataConfig(payload);
-                        frame.setOffsetConfig(offset);
+                        frame.setOffsetConfig(streamOffset + localOffset);
                         frame.setLengthConfig(payload.length);
                         addProducedContainer(frame);
                         // TODO: Add option to pass everything together to the next layer
                         getLowerLayer().sendData(packetLayerHint, writeFrame(frame));
 
-                        offset += toCopy;
-                        if (offset >= data.length) {
+                        localOffset += toCopy;
+                        if (localOffset >= data.length) {
                             break;
                         }
                     }
 
                     // Send fresh crypto frames if not enough frames were specified explicitly
-                    for (; offset < data.length; offset += MAX_FRAME_SIZE) {
+                    for (; localOffset < data.length; localOffset += MAX_FRAME_SIZE) {
                         byte[] payload =
                                 Arrays.copyOfRange(
                                         data,
-                                        offset,
-                                        Math.min(offset + MAX_FRAME_SIZE, data.length));
-                        CryptoFrame frame = new CryptoFrame(payload, offset, payload.length);
+                                        localOffset,
+                                        Math.min(localOffset + MAX_FRAME_SIZE, data.length));
+                        CryptoFrame frame =
+                                new CryptoFrame(
+                                        payload, streamOffset + localOffset, payload.length);
                         addProducedContainer(frame);
                         // TODO: Add option to pass everything together to the next layer
                         getLowerLayer().sendData(packetLayerHint, writeFrame(frame));
+                    }
+
+                    if (hintedFirstMessage) {
+                        initialPhaseSendCryptoOffset += data.length;
+                    } else {
+                        handshakePhaseSendCryptoOffset += data.length;
                     }
                     break;
                 case APPLICATION_DATA:
@@ -473,6 +489,8 @@ public class QuicFrameLayer
         initialPhaseExpectedCryptoFrameOffset = 0;
         handshakePhaseExpectedCryptoFrameOffset = 0;
         applicationPhaseExpectedCryptoFrameOffset = 0;
+        initialPhaseSendCryptoOffset = 0;
+        handshakePhaseSendCryptoOffset = 0;
     }
 
     public boolean hasExperiencedTimeout() {

--- a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/impl/QuicPacketLayer.java
+++ b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/layer/impl/QuicPacketLayer.java
@@ -27,10 +27,12 @@ import de.rub.nds.tlsattacker.core.quic.crypto.QuicEncryptor;
 import de.rub.nds.tlsattacker.core.quic.packet.*;
 import de.rub.nds.tlsattacker.core.state.Context;
 import de.rub.nds.tlsattacker.core.state.quic.QuicContext;
+import de.rub.nds.tlsattacker.transport.ConnectionEndType;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.PortUnreachableException;
 import java.net.SocketTimeoutException;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -271,6 +273,26 @@ public class QuicPacketLayer
                 LOGGER.debug("Discarding QUIC Packet with mismatching SCID.");
             } else {
                 receivedPacketBuffer.get(packetType).add(readPacket);
+            }
+        }
+
+        // Server mode: when first Initial arrives, adopt the client's DCID
+        // and derive Initial secrets from it. Until this point QuicContext has no Initial keys.
+        if (context.getConnection().getLocalConnectionEndType() == ConnectionEndType.SERVER
+                && !quicContext.isInitialSecretsInitialized()
+                && !receivedPacketBuffer.get(QuicPacketType.INITIAL_PACKET).isEmpty()) {
+            byte[] clientDcid =
+                    receivedPacketBuffer
+                            .get(QuicPacketType.INITIAL_PACKET)
+                            .getFirst()
+                            .getDestinationConnectionId()
+                            .getValue();
+            quicContext.setFirstDestinationConnectionId(clientDcid);
+            quicContext.setDestinationConnectionId(clientDcid);
+            try {
+                QuicPacketCryptoComputations.calculateInitialSecrets(quicContext);
+            } catch (NoSuchAlgorithmException | CryptoException ex) {
+                LOGGER.error("Could not derive server-mode Initial secrets", ex);
             }
         }
 

--- a/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/state/quic/QuicContext.java
+++ b/TLS-Core/src/main/java/de/rub/nds/tlsattacker/core/state/quic/QuicContext.java
@@ -20,6 +20,7 @@ import de.rub.nds.tlsattacker.core.quic.constants.QuicVersion;
 import de.rub.nds.tlsattacker.core.quic.frame.ConnectionCloseFrame;
 import de.rub.nds.tlsattacker.core.quic.packet.QuicPacketCryptoComputations;
 import de.rub.nds.tlsattacker.core.state.Context;
+import de.rub.nds.tlsattacker.transport.ConnectionEndType;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import javax.crypto.Cipher;
@@ -150,13 +151,23 @@ public class QuicContext extends LayerContext {
         } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
             e.printStackTrace();
         }
+        this.initialSecretsInitialized = false;
         this.sourceConnectionId = this.generateRandomConnectionId(16);
-        this.firstDestinationConnectionId = this.generateRandomConnectionId(16);
-        this.destinationConnectionId = this.firstDestinationConnectionId;
-        try {
-            QuicPacketCryptoComputations.calculateInitialSecrets(this);
-        } catch (NoSuchAlgorithmException | CryptoException e) {
-            LOGGER.error("Could not initialize initial secrets: ", e);
+        // Initial secrets are derived from client's first DCID, which in server mode we don't know
+        // until the first Initial packet.
+        // Defer derivation to QuicPacketLayer.readPackets. Client mode picks its own DCID and
+        // derives immediately.
+        if (context.getConnection().getLocalConnectionEndType() == ConnectionEndType.SERVER) {
+            this.firstDestinationConnectionId = null;
+            this.destinationConnectionId = new byte[0];
+        } else {
+            this.firstDestinationConnectionId = this.generateRandomConnectionId(16);
+            this.destinationConnectionId = this.firstDestinationConnectionId;
+            try {
+                QuicPacketCryptoComputations.calculateInitialSecrets(this);
+            } catch (NoSuchAlgorithmException | CryptoException e) {
+                LOGGER.error("Could not initialize initial secrets: ", e);
+            }
         }
     }
 

--- a/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/layer/impl/QuicFrameLayerTest.java
+++ b/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/layer/impl/QuicFrameLayerTest.java
@@ -8,7 +8,7 @@
  */
 package de.rub.nds.tlsattacker.core.layer.impl;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.protocol.exception.CryptoException;
@@ -151,6 +151,157 @@ public class QuicFrameLayerTest extends AbstractLayerTest {
                         quicFramePayload);
         assertEquals(
                 Arrays.toString(quicFrameBytes), Arrays.toString(transportHandler.getSentBytes()));
+    }
+
+    /**
+     * Simulates a QUIC server sending multiple Handshake-level TLS messages (e.g.,
+     * EncryptedExtensions, Certificate, CertificateVerify, Finished) as separate CRYPTO frames.
+     * Each message must start at the stream offset where the previous one ended, forming a
+     * continuous byte stream.
+     */
+    @Test
+    public void testHandshakeCryptoFrameOffsetsAdvance() throws IOException {
+        QuicFrameLayer frameLayer = tlsContext.getLayerStack().getLayer(QuicFrameLayer.class);
+
+        byte[] msg1 = new byte[123];
+        byte[] msg2 = new byte[794];
+        byte[] msg3 = new byte[264];
+        Arrays.fill(msg1, (byte) 0xAA);
+        Arrays.fill(msg2, (byte) 0xBB);
+        Arrays.fill(msg3, (byte) 0xCC);
+
+        // hintedFirstMessage=false: Handshake phase
+        QuicFrameLayerHint handshakeHint =
+                new QuicFrameLayerHint(ProtocolMessageType.HANDSHAKE, false);
+
+        // Send message 1
+        frameLayer.setLayerConfiguration(
+                new SpecificSendLayerConfiguration<>(
+                        ImplementedLayers.QUICFRAME, new ArrayList<>()));
+        frameLayer.sendData(handshakeHint, msg1);
+        List<QuicFrame> produced1 = frameLayer.getLayerResult().getUsedContainers();
+        CryptoFrame frame1 = (CryptoFrame) produced1.getLast();
+        assertEquals(0L, frame1.getOffsetConfig(), "First handshake message offset must be 0");
+
+        frameLayer.clear();
+        transportHandler.resetOutputStream();
+
+        // Send message 2
+        frameLayer.setLayerConfiguration(
+                new SpecificSendLayerConfiguration<>(
+                        ImplementedLayers.QUICFRAME, new ArrayList<>()));
+        frameLayer.sendData(handshakeHint, msg2);
+        List<QuicFrame> produced2 = frameLayer.getLayerResult().getUsedContainers();
+        CryptoFrame frame2 = (CryptoFrame) produced2.getFirst();
+        assertEquals(
+                msg1.length,
+                frame2.getOffsetConfig(),
+                "Second handshake message offset must equal first message length");
+
+        frameLayer.clear();
+        transportHandler.resetOutputStream();
+
+        // Send message 3
+        frameLayer.setLayerConfiguration(
+                new SpecificSendLayerConfiguration<>(
+                        ImplementedLayers.QUICFRAME, new ArrayList<>()));
+        frameLayer.sendData(handshakeHint, msg3);
+        List<QuicFrame> produced3 = frameLayer.getLayerResult().getUsedContainers();
+        CryptoFrame frame3 = (CryptoFrame) produced3.getFirst();
+        assertEquals(
+                msg1.length + msg2.length,
+                frame3.getOffsetConfig(),
+                "Third handshake message offset must equal sum of prior message lengths");
+    }
+
+    /**
+     * Verifies that Initial-phase and Handshake-phase CRYPTO stream offsets are tracked
+     * independently. Sending Initial data should not affect Handshake offsets and vice versa.
+     */
+    @Test
+    public void testInitialAndHandshakeOffsetsAreIndependent() throws IOException {
+        QuicFrameLayer frameLayer = tlsContext.getLayerStack().getLayer(QuicFrameLayer.class);
+
+        byte[] initialData = new byte[200];
+        byte[] handshakeData1 = new byte[150];
+        byte[] handshakeData2 = new byte[300];
+
+        QuicFrameLayerHint initialHint =
+                new QuicFrameLayerHint(ProtocolMessageType.HANDSHAKE, true);
+        QuicFrameLayerHint handshakeHint =
+                new QuicFrameLayerHint(ProtocolMessageType.HANDSHAKE, false);
+
+        // Send Initial-phase message
+        frameLayer.setLayerConfiguration(
+                new SpecificSendLayerConfiguration<>(
+                        ImplementedLayers.QUICFRAME, new ArrayList<>()));
+        frameLayer.sendData(initialHint, initialData);
+        CryptoFrame initialFrame =
+                (CryptoFrame) frameLayer.getLayerResult().getUsedContainers().getFirst();
+        assertEquals(0L, initialFrame.getOffsetConfig(), "Initial phase offset starts at 0");
+
+        frameLayer.clear();
+        transportHandler.resetOutputStream();
+
+        // Send first Handshake-phase message: offset must be 0
+        frameLayer.setLayerConfiguration(
+                new SpecificSendLayerConfiguration<>(
+                        ImplementedLayers.QUICFRAME, new ArrayList<>()));
+        frameLayer.sendData(handshakeHint, handshakeData1);
+        CryptoFrame hsFrame1 =
+                (CryptoFrame) frameLayer.getLayerResult().getUsedContainers().getFirst();
+        assertEquals(
+                0L,
+                hsFrame1.getOffsetConfig(),
+                "First Handshake message offset must be 0 (independent of Initial phase)");
+
+        frameLayer.clear();
+        transportHandler.resetOutputStream();
+
+        // Send second Handshake-phase message: offset must advance by handshakeData1.length
+        frameLayer.setLayerConfiguration(
+                new SpecificSendLayerConfiguration<>(
+                        ImplementedLayers.QUICFRAME, new ArrayList<>()));
+        frameLayer.sendData(handshakeHint, handshakeData2);
+        CryptoFrame hsFrame2 =
+                (CryptoFrame) frameLayer.getLayerResult().getUsedContainers().getFirst();
+        assertEquals(
+                handshakeData1.length,
+                hsFrame2.getOffsetConfig(),
+                "Second Handshake message offset must equal first Handshake message length");
+    }
+
+    /** Verifies that clearCryptoFrameBuffer() resets send offsets */
+    @Test
+    public void testClearCryptoFrameBufferResetsSendOffsets() throws IOException {
+        QuicFrameLayer frameLayer = tlsContext.getLayerStack().getLayer(QuicFrameLayer.class);
+
+        byte[] data = new byte[100];
+        QuicFrameLayerHint handshakeHint =
+                new QuicFrameLayerHint(ProtocolMessageType.HANDSHAKE, false);
+
+        // Send once to advance the offset
+        frameLayer.setLayerConfiguration(
+                new SpecificSendLayerConfiguration<>(
+                        ImplementedLayers.QUICFRAME, new ArrayList<>()));
+        frameLayer.sendData(handshakeHint, data);
+        frameLayer.clear();
+        transportHandler.resetOutputStream();
+
+        // Clear the crypto frame buffer
+        frameLayer.clearCryptoFrameBuffer();
+
+        // Send again: offset should be back to 0
+        frameLayer.setLayerConfiguration(
+                new SpecificSendLayerConfiguration<>(
+                        ImplementedLayers.QUICFRAME, new ArrayList<>()));
+        frameLayer.sendData(handshakeHint, data);
+        CryptoFrame frame =
+                (CryptoFrame) frameLayer.getLayerResult().getUsedContainers().getFirst();
+        assertEquals(
+                0L,
+                frame.getOffsetConfig(),
+                "After clearCryptoFrameBuffer, offset must be 0 again");
     }
 
     @Test

--- a/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/state/quic/QuicContextServerModeTest.java
+++ b/TLS-Core/src/test/java/de/rub/nds/tlsattacker/core/state/quic/QuicContextServerModeTest.java
@@ -1,0 +1,165 @@
+/*
+ * TLS-Attacker - A Modular Penetration Testing Framework for TLS
+ *
+ * Copyright 2014-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.tlsattacker.core.state.quic;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.rub.nds.tlsattacker.core.config.Config;
+import de.rub.nds.tlsattacker.core.config.delegate.QuicDelegate;
+import de.rub.nds.tlsattacker.core.config.delegate.ServerDelegate;
+import de.rub.nds.tlsattacker.core.quic.packet.QuicPacketCryptoComputations;
+import de.rub.nds.tlsattacker.core.state.State;
+import org.junit.jupiter.api.Test;
+
+/** Tests that QuicContext correctly defers Initial secret derivation in server mode */
+public class QuicContextServerModeTest {
+
+    @Test
+    public void testServerModeDefersDcidAndSecrets() {
+        Config config = new Config();
+        new QuicDelegate(true).applyDelegate(config);
+        new ServerDelegate() {
+            {
+                setPort(4433);
+            }
+        }.applyDelegate(config);
+
+        State state = new State(config);
+        QuicContext quicContext = state.getContext().getQuicContext();
+
+        assertNull(
+                quicContext.getFirstDestinationConnectionId(),
+                "Server mode must not generate firstDestinationConnectionId at init");
+        assertEquals(
+                0,
+                quicContext.getDestinationConnectionId().length,
+                "Server mode destinationConnectionId should be empty until client's Initial arrives");
+        assertFalse(
+                quicContext.isInitialSecretsInitialized(),
+                "Server mode must not derive Initial secrets at init");
+        assertNotNull(
+                quicContext.getSourceConnectionId(),
+                "Server mode should still generate its own SCID");
+        assertTrue(
+                quicContext.getSourceConnectionId().length > 0, "Server SCID should be non-empty");
+    }
+
+    @Test
+    public void testClientModeInitializesSecretsImmediately() {
+        Config config = new Config();
+        new QuicDelegate(true).applyDelegate(config);
+
+        State state = new State(config);
+        QuicContext quicContext = state.getContext().getQuicContext();
+
+        assertNotNull(
+                quicContext.getFirstDestinationConnectionId(),
+                "Client mode must generate firstDestinationConnectionId at init");
+        assertTrue(
+                quicContext.getFirstDestinationConnectionId().length > 0,
+                "Client DCID should be non-empty");
+        assertArrayEquals(
+                quicContext.getFirstDestinationConnectionId(),
+                quicContext.getDestinationConnectionId(),
+                "Client mode: destinationConnectionId must equal firstDestinationConnectionId");
+        assertTrue(
+                quicContext.isInitialSecretsInitialized(),
+                "Client mode must derive Initial secrets at init");
+        assertNotNull(quicContext.getInitialClientKey(), "Client Initial key should be derived");
+        assertNotNull(quicContext.getInitialServerKey(), "Server Initial key should be derived");
+    }
+
+    /** Verifies that both client and server modes derive the same keys from the same DCID. */
+    @Test
+    public void testSameDcidProducesSameSecrets() throws Exception {
+        byte[] sharedDcid = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+
+        // Client mode: set a known DCID
+        Config clientConfig = new Config();
+        new QuicDelegate(true).applyDelegate(clientConfig);
+        State clientState = new State(clientConfig);
+        QuicContext clientCtx = clientState.getContext().getQuicContext();
+        clientCtx.setFirstDestinationConnectionId(sharedDcid);
+        clientCtx.setInitialSecretsInitialized(false);
+        QuicPacketCryptoComputations.calculateInitialSecrets(clientCtx);
+
+        // Server mode: simulate receiving a client Initial with the same DCID
+        Config serverConfig = new Config();
+        new QuicDelegate(true).applyDelegate(serverConfig);
+        new ServerDelegate() {
+            {
+                setPort(4433);
+            }
+        }.applyDelegate(serverConfig);
+        State serverState = new State(serverConfig);
+        QuicContext serverCtx = serverState.getContext().getQuicContext();
+
+        assertFalse(serverCtx.isInitialSecretsInitialized(), "Pre-condition: no secrets yet");
+        serverCtx.setFirstDestinationConnectionId(sharedDcid);
+        QuicPacketCryptoComputations.calculateInitialSecrets(serverCtx);
+
+        assertTrue(serverCtx.isInitialSecretsInitialized(), "Secrets should now be initialized");
+        assertArrayEquals(
+                clientCtx.getInitialClientKey(),
+                serverCtx.getInitialClientKey(),
+                "Client Initial key must match between client-mode and server-mode derivation");
+        assertArrayEquals(
+                clientCtx.getInitialServerKey(),
+                serverCtx.getInitialServerKey(),
+                "Server Initial key must match between client-mode and server-mode derivation");
+        assertArrayEquals(
+                clientCtx.getInitialClientIv(),
+                serverCtx.getInitialClientIv(),
+                "Client Initial IV must match");
+        assertArrayEquals(
+                clientCtx.getInitialServerIv(),
+                serverCtx.getInitialServerIv(),
+                "Server Initial IV must match");
+    }
+
+    @Test
+    public void testResetReturnsToUninitializedInServerMode() {
+        Config config = new Config();
+        new QuicDelegate(true).applyDelegate(config);
+        new ServerDelegate() {
+            {
+                setPort(4433);
+            }
+        }.applyDelegate(config);
+
+        State state = new State(config);
+        QuicContext quicContext = state.getContext().getQuicContext();
+
+        // Simulate having received a client Initial and derived secrets
+        byte[] clientDcid = new byte[] {0x0a, 0x0b, 0x0c, 0x0d};
+        quicContext.setFirstDestinationConnectionId(clientDcid);
+        quicContext.setDestinationConnectionId(clientDcid);
+        try {
+            de.rub.nds.tlsattacker.core.quic.packet.QuicPacketCryptoComputations
+                    .calculateInitialSecrets(quicContext);
+        } catch (Exception e) {
+            fail("Secret derivation should succeed: " + e.getMessage());
+        }
+        assertTrue(quicContext.isInitialSecretsInitialized());
+
+        // Reset should return to deferred state
+        quicContext.reset();
+
+        assertNull(
+                quicContext.getFirstDestinationConnectionId(),
+                "After reset, server-mode firstDCID should be null again");
+        assertEquals(
+                0,
+                quicContext.getDestinationConnectionId().length,
+                "After reset, server-mode DCID should be empty again");
+        assertFalse(
+                quicContext.isInitialSecretsInitialized(),
+                "After reset, server-mode secrets should not be initialized");
+    }
+}


### PR DESCRIPTION
This PR fixes two bugs when using TLS-Attacker as a QUIC server.

See notes for reproducing at the end.

# Bug 1: Initial secrets derived from wrong DCID

`QuicContext.init()` always generates a random `firstDestinationConnectionId` and calls `calculateInitialSecrets()`.
The RFC requires both peers to derive Initial secrets from the DCID in the client's first Initial packet.

The branch that "fixes" on receive in `InitialPacketHandler.adjustContext()` is not reached here, because it runs after the decryption (and the condition is false since `isInitialSecretsInitialized` is true).

Fixes for this are in commit `6f71eb5f6edf713d67e2af0b8e033256e7d5b444`: 


- `QuiContext.init()`: when in SERVER mode skip calculating initial secrets
- `QuicPacketLayer.readPackets()`: after parsing packets, if in server mode and secrets not yet initialized, adopt the first Initial's DCID and calculate secrets 

# Bug 2: CRYPTO frame offsets always zero on send path

`sendDataInternal()` uses a local `offset` each time it is called. This leads to all CRYPTO frames in the Handshake being emitted at stream offset 0, when they should be continuously increasing depending on message sizes.

Fixes for this are in commit `9659763ac5eb08151df1ba6209dbff0d1536b7f1`:

- add per-encryption-level send offset counters to `QuicFrameLayer` . Use tracked offset as base for each call and advance by `data.length`.

# Reproduction

### Prerequisites

- Java 21, Maven
- Python 3 with aioquic: `pip install aioquic`

### Automated

Drop [`reproduce.sh`](reproduce.sh) and [`ServerModeQuicRepro.java`](ServerModeQuicRepro.java) into a directory, then:

```sh
./reproduce.sh /path/to/TLS-Attacker
```

The script generates a throwaway cert, compiles the Java repro against TLS-Attacker's classpath, starts the server, connects an aioquic client, and reports PASS/FAIL.

<details>

<summary>ServerModeQuicRepro.java</summary>

```java
import de.rub.nds.tlsattacker.core.config.Config;
import de.rub.nds.tlsattacker.core.config.delegate.CertificateDelegate;
import de.rub.nds.tlsattacker.core.config.delegate.QuicDelegate;
import de.rub.nds.tlsattacker.core.config.delegate.ServerDelegate;
import de.rub.nds.tlsattacker.core.protocol.message.*;
import de.rub.nds.tlsattacker.core.protocol.message.extension.quic.QuicTransportParametersExtensionMessage;
import de.rub.nds.tlsattacker.core.state.State;
import de.rub.nds.tlsattacker.core.workflow.*;
import de.rub.nds.tlsattacker.core.workflow.action.GenericReceiveAction;
import de.rub.nds.tlsattacker.core.workflow.action.SendAction;

/**
 * Minimal reproduction for QUIC server-mode bugs.
 * Uses stepped execution so we can set original_destination_connection_id
 * from the received client DCID between receive and send.
 */
public final class ServerModeQuicRepro {
    public static void main(String[] args) throws Exception {
        String certPath = "certs/server.crt", keyPath = "certs/server.key";
        int port = 4433;
        for (int i = 0; i < args.length; i++) {
            switch (args[i]) {
                case "--cert": certPath = args[++i]; break;
                case "--key":  keyPath  = args[++i]; break;
                case "--port": port = Integer.parseInt(args[++i]); break;
            }
        }

        Config config = new Config();
        new QuicDelegate(true).applyDelegate(config);
        ServerDelegate srv = new ServerDelegate();
        srv.setPort(port);
        srv.applyDelegate(config);
        CertificateDelegate cert = new CertificateDelegate();
        cert.setCertificate(certPath);
        cert.setKey(keyPath);
        cert.applyDelegate(config);
        config.setDiscardPacketsWithMismatchedSCID(false);
        config.setRespectClientProposedExtensions(true);
        config.getDefaultServerConnection().setTimeout(5000);

        State state = new State(config, new WorkflowTrace());
        WorkflowExecutor exec = WorkflowExecutorFactory.createWorkflowExecutor(
                config.getWorkflowExecutorType(), state);
        exec.initAllLayer();

        System.out.println("[repro] QUIC server listening on port " + port);

        try {
            new GenericReceiveAction("server").execute(state);

            byte[] odcid = state.getContext("server").getQuicContext()
                    .getFirstDestinationConnectionId();
            if (odcid != null)
                config.getDefaultQuicTransportParameters()
                        .setOriginalDestinationConnectionId(odcid);

            EncryptedExtensionsMessage ee = new EncryptedExtensionsMessage();
            ee.addExtension(new QuicTransportParametersExtensionMessage(config));
            new SendAction("server",
                    new ServerHelloMessage(), ee, new CertificateMessage(),
                    new CertificateVerifyMessage(), new FinishedMessage())
                    .execute(state);

            new GenericReceiveAction("server").execute(state);

            System.out.println("[repro] executedAsPlanned=true");
        } catch (Exception e) {
            System.out.println("[repro] EXCEPTION: " + e.getClass().getSimpleName());
            for (Throwable c = e.getCause(); c != null; c = c.getCause())
                System.out.println("[repro]   caused by: " + c.getClass().getSimpleName()
                        + ": " + c.getMessage());
            System.out.println("[repro] executedAsPlanned=false");
        }
    }
}
```

</details>

<details>

<summary>reproduce.sh</summary>

```sh
#!/usr/bin/env bash
# Reproduces TLS-Attacker QUIC server-mode bugs.
# Run from the TLS-Attacker repo root after `mvn install -DskipTests`.
#
# Prerequisites: Java 21, Maven, Python 3 + aioquic (pip install aioquic)
#
# Usage:
#   ./reproduce.sh                          # uses cwd as TLS-Attacker root
#   ./reproduce.sh /path/to/TLS-Attacker    # explicit path
set -euo pipefail

SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
TA_DIR="${1:-$(pwd)}"
PORT=4433
SERVER_PID=""
TMPDIR=""

cleanup() {
    [[ -n "$SERVER_PID" ]] && kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null || true
    [[ -n "$TMPDIR" ]] && rm -rf "$TMPDIR"
}
trap cleanup EXIT

die() { echo "FATAL: $*" >&2; exit 2; }

# --- prerequisites ---

command -v java >/dev/null || die "java not found"
command -v mvn  >/dev/null || die "mvn not found"

PYTHON="${PYTHON:-}"
if [[ -z "$PYTHON" ]]; then
    for p in python3 python; do
        if command -v "$p" >/dev/null && "$p" -c "import aioquic" 2>/dev/null; then
            PYTHON="$p"; break
        fi
    done
fi
[[ -n "$PYTHON" ]] && "$PYTHON" -c "import aioquic" 2>/dev/null || \
    die "No Python with aioquic found. Install: pip install aioquic (or set PYTHON=...)"

[[ -f "$TA_DIR/pom.xml" ]] || die "$TA_DIR does not look like a TLS-Attacker checkout"

echo "TLS-Attacker: $TA_DIR ($(cd "$TA_DIR" && git log --oneline -1 2>/dev/null || echo 'no git'))"
echo "Java: $(java -version 2>&1 | head -1)"
echo ""

# --- setup ---

TMPDIR=$(mktemp -d)

# certs
mkdir -p "$TMPDIR/certs"
openssl req -x509 -newkey rsa:2048 -keyout "$TMPDIR/certs/server.key" \
    -out "$TMPDIR/certs/server.crt" -days 1 -nodes -subj "/CN=localhost" 2>/dev/null

# classpath from TLS-Attacker's local install
CP_FILE="$TMPDIR/cp.txt"
(cd "$TA_DIR" && mvn -q -pl TLS-Core dependency:build-classpath -Dmdep.outputFile="$CP_FILE" 2>&1) || \
    die "mvn dependency:build-classpath failed — did you run 'mvn install -DskipTests'?"
# include TLS-Core's own classes
TA_CLASSES="$TA_DIR/TLS-Core/target/classes"
[[ -d "$TA_CLASSES" ]] || die "$TA_CLASSES not found — run 'mvn compile' first"
CP="$TA_CLASSES:$(cat "$CP_FILE")"

# compile repro
javac -d "$TMPDIR" -cp "$CP" "$SCRIPT_DIR/ServerModeQuicRepro.java" \
    -Xlint:-options -proc:none || die "Compilation failed"

# --- run ---

echo "Starting server on port $PORT..."
java -Djava.net.preferIPv4Stack=true -cp "$TMPDIR:$CP" \
    ServerModeQuicRepro --port "$PORT" \
    --cert "$TMPDIR/certs/server.crt" --key "$TMPDIR/certs/server.key" \
    >"$TMPDIR/server.log" 2>&1 &
SERVER_PID=$!
sleep 1

if ! kill -0 "$SERVER_PID" 2>/dev/null; then
    echo "Server exited early:"
    grep -E '^\[repro\]|Exception' "$TMPDIR/server.log"
    SERVER_PID=""
    die "Server failed to start"
fi

echo "Running aioquic client..."
"$PYTHON" -c "
import asyncio
from aioquic.asyncio.client import connect
from aioquic.quic.configuration import QuicConfiguration
async def main():
    cfg = QuicConfiguration(is_client=True, alpn_protocols=['hq-interop'])
    cfg.verify_mode = 0
    async with connect('127.0.0.1', $PORT, configuration=cfg):
        print('OK handshake_completed')
asyncio.run(asyncio.wait_for(main(), timeout=10))
" >"$TMPDIR/client.log" 2>&1 || true

# wait for server to exit
for _ in $(seq 15); do kill -0 "$SERVER_PID" 2>/dev/null || break; sleep 1; done
kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true
SERVER_PID=""

# --- results ---

echo ""
echo "=== Server ==="
grep '^\[repro\]' "$TMPDIR/server.log" || echo "(no output)"
echo ""
echo "=== Client ==="
cat "$TMPDIR/client.log"
echo ""

if grep -q 'executedAsPlanned=true' "$TMPDIR/server.log" && \
   grep -q 'OK handshake_completed' "$TMPDIR/client.log"; then
    echo "RESULT: PASS"
    exit 0
else
    echo "RESULT: FAIL"
    if grep -q 'AEADBadTagException' "$TMPDIR/server.log"; then
        echo "  -> Bug 1: Initial secrets derived from wrong DCID (AEADBadTagException)"
    fi
    exit 1
fi
```

</details>

<details>

<summary>Output before fix</summary>

```sh
TLS-Attacker: ../TLS-Attacker (1d2a3dffa release: v7.7.0)
Java: openjdk version "21.0.11" 2026-04-21

Starting server on port 4433...
Running aioquic client...

=== Server ===
[repro] QUIC server listening on port 4433
[repro] EXCEPTION: WorkflowExecutionException
[repro]   caused by: CryptoException: Could not decrypt packet
[repro]   caused by: CryptoException: Could not decrypt INITIAL_PACKET
[repro]   caused by: AEADBadTagException: Tag mismatch
[repro] executedAsPlanned=false

=== Client ===
ConnectionError exception in shielded future
future: <Future finished exception=ConnectionError()>
ConnectionError
Traceback (most recent call last):
  File "/usr/lib/python3.14/asyncio/tasks.py", line 488, in wait_for
    return await fut
           ^^^^^^^^^
  File "<string>", line 8, in main
    async with connect('127.0.0.1', 4433, configuration=cfg):
               ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/contextlib.py", line 214, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/sev/projects/quicSML/.venv-sul/lib/python3.14/site-packages/aioquic/asyncio/client.py", line 93, in connect
    await protocol.wait_connected()
  File "/home/sev/projects/quicSML/.venv-sul/lib/python3.14/site-packages/aioquic/asyncio/protocol.py", line 146, in wait_connected
    await asyncio.shield(self._connected_waiter)
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 10, in <module>
    asyncio.run(asyncio.wait_for(main(), timeout=10))
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/asyncio/runners.py", line 204, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/usr/lib/python3.14/asyncio/runners.py", line 127, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib/python3.14/asyncio/base_events.py", line 719, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/asyncio/tasks.py", line 487, in wait_for
    async with timeouts.timeout(timeout):
               ~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/lib/python3.14/asyncio/timeouts.py", line 114, in __aexit__
    raise TimeoutError from exc_val
TimeoutError

RESULT: FAIL
  -> Bug 1: Initial secrets derived from wrong DCID (AEADBadTagException)
```

</details>

<details>

<summary>Output after fix</summary>

```sh
TLS-Attacker: ../TLS-Attacker (34fc23088 add tests)
Java: openjdk version "21.0.11" 2026-04-21

Starting server on port 4433...
Running aioquic client...

=== Server ===
[repro] QUIC server listening on port 4433
[repro] executedAsPlanned=true

=== Client ===
OK handshake_completed

RESULT: PASS
```

</details>

### Note on ODCID

TLS-Attacker does not set the original destination connection ID by itself. I was not sure whether this is intended behavior so a fix for that is not included here. 